### PR TITLE
Fix `AttributeError` in `Context.delete_messages()` (#4876)

### DIFF
--- a/redbot/core/commands/context.py
+++ b/redbot/core/commands/context.py
@@ -188,7 +188,7 @@ class Context(DPYContext):
                 else:
                     try:
                         await self.channel.delete_messages((query, resp))
-                    except discord.HTTPException:
+                    except (discord.HTTPException, AttributeError):
                         # In case the bot can't delete other users' messages,
                         # or is not a bot account
                         # or channel is a DM


### PR DESCRIPTION
delete_messages() isn't an attribute of DMChannels

### Type

- [ ] Bugfix
- [ ] Enhancement
- [ ] New feature

### Description of the changes
